### PR TITLE
surround JSON.parse with try/catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,15 @@ module.exports = function(title, cb) {
   });
 
   function handleContent(content) {
-    content = JSON.parse(content);
+    
+    // need try catch here in case parse throws an exception
+    try {
+      content = JSON.parse(content);
+    }
+    catch(ex) {
+      return;
+    }
+    
 
     if (!content.query) {
       cb(null, 'Query Not Found');


### PR DESCRIPTION
While using this utility I came across a wiki entry that was returning malformed json and causing parse to throw an exception and crash my program.