### PR TITLE
Add error handling for unexpected JSON payloads, add callback to user defined function after we catch the parse error fixed in PR 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = function(title, callback) {
     try {
       content = JSON.parse(content);
     } catch(e) {
+      cb(e);
       return;
     }
 
@@ -46,6 +47,9 @@ module.exports = function(title, callback) {
     if (key.indexOf('-1') === 0) {
       callback(null, 'Page Index Not Found');
       return;
+    } else if(!json[key]){
+    	cb("error: malformed response payload");
+    	return;
     } else if (json[key].revisions[0]['*'].indexOf('REDIRECT') > -1) {
       callback(null, json[key].revisions[0]['*']);
       return;


### PR DESCRIPTION
I had a null reference exception "can not access revisions of null". The page name was: "Wy┼╝sza Szko┼éa Filologiczna" This was the only one that threw the error out of 30k wiki pages that I processed. I just added a check and returned an error message if that key happens to be null.

I also forgot to add a callback in my original PR at line 35, so I've included that as well. It would be a good idea to let the parse error trickle back down to the user in case they are using that callback function to iterate through a list, otherwise the program would halt.